### PR TITLE
Change c.std value to standard c99

### DIFF
--- a/build/root.build
+++ b/build/root.build
@@ -1,4 +1,4 @@
-c.std = gnu99
+c.std = 99
 cxx.std = latest
 
 using c


### PR DESCRIPTION
Closes #4 

From [lua doc](https://www.lua.org/manual/5.4/manual.html)

> Lua is implemented as a library, written in clean C, the common subset of standard C and C++. 

[CI](https://ci.stage.build2.org/@1b1ee7ee-707e-4122-abba-0312070ddf40?builds=&pv=&th=*&tg=&tc=&pc=&rs=*)